### PR TITLE
feat: implement `canCheckAuthentication` (Android)

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.java
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.java
@@ -34,6 +34,7 @@ public class KeychainModule extends ReactContextBaseJavaModule {
     public static final String E_SUPPORTED_BIOMETRY_ERROR = "E_SUPPORTED_BIOMETRY_ERROR";
     public static final String KEYCHAIN_MODULE = "RNKeychainManager";
     public static final String FINGERPRINT_SUPPORTED_NAME = "Fingerprint";
+    public static final String AUTHENTICATION_TYPE_BIOMETRICS = "AuthenticationWithBiometrics";
     public static final String EMPTY_STRING = "";
 
     private final Map<String, CipherStorage> cipherStorageMap = new HashMap<>();
@@ -223,6 +224,23 @@ public class KeychainModule extends ReactContextBaseJavaModule {
         } catch (Exception e) {
             Log.e(KEYCHAIN_MODULE, e.getMessage());
             promise.reject(E_SUPPORTED_BIOMETRY_ERROR, e);
+        }
+    }
+
+    @ReactMethod
+    public void canCheckAuthentication(ReadableMap options, Promise promise) {
+        try {
+            String authenticationType = options != null ? options.getString("authenticationType") : null;
+            boolean biometricsOnly = AUTHENTICATION_TYPE_BIOMETRICS.equals(authenticationType);
+
+            if (biometricsOnly) {
+                promise.resolve(isFingerprintAuthAvailable());
+            } else {
+                promise.resolve(DeviceAvailability.isDeviceSecure(getReactApplicationContext()));
+            }
+        } catch (Exception e) {
+            Log.e(KEYCHAIN_MODULE, e.getMessage());
+            promise.resolve(false);
         }
     }
 

--- a/index.js
+++ b/index.js
@@ -73,13 +73,10 @@ export function getSecurityLevel(): Promise<?($Values<typeof SECURITY_LEVEL>)> {
 /**
  * Inquire if the type of local authentication policy (LAPolicy) is supported
  * on this device with the device settings the user chose.
- * @param {object} options LAPolicy option, iOS only
+ * @param {object} options LAPolicy option
  * @return {Promise} Resolves to `true` when supported, otherwise `false`
  */
 export function canImplyAuthentication(options?: Options): Promise<boolean> {
-  if (!RNKeychainManager.canCheckAuthentication) {
-    return Promise.resolve(false);
-  }
   return RNKeychainManager.canCheckAuthentication(options);
 }
 


### PR DESCRIPTION
Implements `canCheckAuthentication` on the native side and removes the unnecessary `canCheckAuthentication` existence check in the JS code

## Testing

- [ ] `canImplyAuthentication` should return true on Android when pin/fingerprint is enabled
- [ ] `canImplyAuthentication` should return false on Android when device is not secured