### PR TITLE
feat: disable AES-GCM temporarily

### DIFF
--- a/android/src/main/java/com/oblador/keychain/KeychainModule.kt
+++ b/android/src/main/java/com/oblador/keychain/KeychainModule.kt
@@ -148,8 +148,8 @@ class KeychainModule(reactContext: ReactApplicationContext) :
   init {
     prefsStorage = DataStorePrefsStorage(reactContext, coroutineScope)
     addCipherStorageToMap(CipherStorageKeystoreAesCbc(reactContext))
-    addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, false))
-    addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, true))
+    // addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, false))
+    // addCipherStorageToMap(CipherStorageKeystoreAesGcm(reactContext, true))
 
     // we have a references to newer api that will fail load of app classes in old androids OS
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {


### PR DESCRIPTION
AES-GCM is a one way street, once it's been rolled out to users, there's no going back. It's potentially a high risk change, let's roll this out in stages. First all the other changes that should be compatible with our older v4.x.x release and then consider re-enabling this.